### PR TITLE
Added audio and video elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,1 @@
-module.exports = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable]'
+module.exports = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls]'


### PR DESCRIPTION
The `audio` and `video` HTML elements featuring the `controls` attribute should be included as focusable elements.

Might be able to add a few more as specified from: https://allyjs.io/data-tables/focusable.html.