### PR TITLE
Support <div tabindex="\d+">

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,1 @@
-function tabindexes () {
-  var result = ''
-  for (var i = 0; i <= 9; i++) {
-    result += ', [tabindex^="' + i + '"]'
-  }
-  return result
-}
-
-module.exports = 'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls], summary, '  + tabindexes()
+module.exports = 'a[href], area[href], input:not([disabled]):not([type="hidden"]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls], summary, [tabindex^="0"], [tabindex^="1"], [tabindex^="2"], [tabindex^="3"], [tabindex^="4"], [tabindex^="5"], [tabindex^="6"], [tabindex^="7"], [tabindex^="8"], [tabindex^="9"]'

--- a/index.js
+++ b/index.js
@@ -1,1 +1,9 @@
-module.exports = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls], summary'
+function tabindexes () {
+  var result = ''
+  for (var i = 0; i <= 9; i++) {
+    result += ', [tabindex^="' + i + '"]'
+  }
+  return result
+}
+
+module.exports = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex="0"], [contenteditable], audio[controls], video[controls], summary, ' + tabindexes()


### PR DESCRIPTION
Fixes #7 

I added the function which will generate `[tabindex^="0"],[tabindex^="1"],[tabindex^="2"],[tabindex^="3"],[tabindex^="4"],[tabindex^="5"],[tabindex^="6"],[tabindex^="7"],[tabindex^="8"],[tabindex^="9"]` and add that to the existed selector.

---

My first attempt was `[tabindex]:not([tabindex="-1"])`, but as it was correctly pointed by @stephenmathieson that will not cover all edge cases, e.g. 

 - `<div tabndex>` shouldn't be focusable
 - `<div tabndex="hello">` shouldn't be focusable
 - `<div tabndex="-2">` shouldn't be focusable

---

@jkup if you'd prefer just adding `[tabindex^="0"],[tabindex^="1"],[tabindex^="2"],[tabindex^="3"],[tabindex^="4"],[tabindex^="5"],[tabindex^="6"],[tabindex^="7"],[tabindex^="8"],[tabindex^="9"]` as plain string without a generator function, I'm fine with that as well, let me know :+1: 